### PR TITLE
When the user start a task, go to another and then go back to the fir…

### DIFF
--- a/src/app/assembly/assembly.controller.js
+++ b/src/app/assembly/assembly.controller.js
@@ -15,6 +15,8 @@ angular.module('prodapps')
             return;
 
         newVal._v = newVal._v || {};
+        newVal._v.started = false; //re-init if user had clicked to another task and he is back now.
+        // it should restart the start trigger
 
 
         fetchPdf(newVal);


### PR DESCRIPTION
…st one

we have this issue where start button is shown and the task is partially displayed underneath
This fix ensure to come back to not started state when switching tasks.